### PR TITLE
docs: link config docs + clarify preset intent

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,28 @@ The hook creates these directories automatically:
 - `~/.claude/session-states/` - Session state persistence
 - `~/.claude/logs/` - Debug logs (when enabled)
 
+If you want to change what gets logged (channels, routing, per-tool overrides):
+
+- Start here: **[docs/configuration.md](docs/configuration.md)**
+- Full channel/category/tool reference: **[docs/channels.md](docs/channels.md)**
+
+### Common Configurations
+
+- Minimal shell history (copy-pasteable `.shell_*.log`, nothing else)
+  - Use preset: `examples/session-logger-minimal.json`
+- Conversation replay (only `.convo_*.log` — useful for reconstructing prompts/responses)
+  - Use preset: `examples/session-logger-conversation-replay.json`
+- Agent debugging (split by agent/subagent, easier to see who's doing what)
+  - Use preset: `examples/session-logger-agent-debug.json`
+- Power user (everything on + subtype splits)
+  - Use preset: `examples/session-logger-power-user.json`
+
+Copy a preset into place:
+
+```bash
+cp examples/session-logger-minimal.json ~/.claude/plugins/settings/session-logger.json
+```
+
 ### Debug Logging
 
 To enable debug logging, the hook writes to `~/.claude/logs/hook-debug.log`. Check this file if hooks aren't working as expected.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -135,10 +135,12 @@ Drop-in starting points:
 | Preset file | Use case |
 |---|---|
 | `session-logger.json` | Default — all channels enabled, no subtype splits |
-| `session-logger-minimal.json` | Only `.shell_*.log` (copy-pasteable shell history) |
+| `session-logger-minimal.json` | Only `.shell_*.log` (copy-pasteable shell history). Also works as “shell-history-only”. |
 | `session-logger-power-user.json` | Everything enabled including all subtype splits |
 | `session-logger-agent-debug.json` | Focus on agent dialogue with per-agent split |
 | `session-logger-conversation-replay.json` | Only conversation prose (user/AI/agent) |
+
+Note: there are **four** “alternate” presets (`minimal`, `power-user`, `agent-debug`, `conversation-replay`) plus the default `session-logger.json`.
 
 Copy any preset to `~/.claude/plugins/settings/session-logger.json` and adjust.
 

--- a/examples/session-logger-minimal.json
+++ b/examples/session-logger-minimal.json
@@ -1,6 +1,6 @@
 {
   "$schema": "../hooks/schemas/session-logger.schema.json",
-  "_comment": "MINIMAL preset: only the curated shell history channel. For users who want a copy-pasteable shell log and nothing else.",
+  "_comment": "MINIMAL preset: only the curated shell history channel. This covers both the 'minimal' and 'shell-history-only' use cases.",
 
   "routing": {
     "channels": {


### PR DESCRIPTION
Small docs-only cleanup to make configuration easier to discover.

- README: link to docs/configuration.md + docs/channels.md, and add a quick 'Common Configurations' section that points at the existing example presets
- docs/configuration.md: note that session-logger-minimal.json also serves the 'shell-history-only' use case, and clarify preset counts (4 alternates + default)
- examples/session-logger-minimal.json: tweak _comment to match the above

Relates to #41 (items 2 + 3).